### PR TITLE
fix UI gameplay issues

### DIFF
--- a/Card.py
+++ b/Card.py
@@ -1,68 +1,69 @@
 class Card:
 
-	def __init__(self,suit,value,worth,img_path):
-		self.suit = suit
-		self.value = value
-		self.is_trump = False
-		self.worth = int(worth)
-		self.is_left = False
-		self.img_path = img_path
-		self.rect = None
-	
-	def get_suit(self):
-		return self.suit
+    def __init__(self,suit,value,worth,img_path):
+        self.suit = suit
+        self.value = value
+        self.is_trump = False
+        self.worth = int(worth)
+        self.is_left = False
+        self.img_path = img_path
+        self.rect = None
+    
+    def get_suit(self):
+        return self.suit
 
-	def get_value(self):
-		return self.value
+    def get_value(self):
+        return self.value
 
-	def get_desc(self):
-		return [self.suit,self.value]
+    def get_desc(self):
+        return [self.suit,self.value]
 
-	def get_img_path(self):
-		return self.img_path
+    def get_img_path(self):
+        return self.img_path
 
-	def set_rect(self, rect):
-		self.rect = rect
+    def set_rect(self, rect):
+        self.rect = rect
 
-	def get_rect(self):
-		return self.rect
+    def get_rect(self):
+        return self.rect
 
-	#6 was chosen because a 9 of trump can beat any non-trump ace
-	def set_trump(self): 
-		self.is_trump = True
+    #6 was chosen because a 9 of trump can beat any non-trump ace
+    def set_trump(self): 
+        self.is_trump = True
 
-		#Nine
-		if self.worth == 1:
-			self.worth = 7
-		#Ten
-		elif self.worth == 2:
-			self.worth = 8
-		#Jack
-		elif self.worth == 3:
-			self.worth = 13
-		#Queen
-		elif self.worth == 4:
-			self.worth = 9
-		#King
-		elif self.worth == 5:
-			self.worth = 10
-		#Ace
-		elif self.worth == 6:
-			self.worth = 11
+        #Nine
+        if self.worth == 1:
+            self.worth = 7
+        #Ten
+        elif self.worth == 2:
+            self.worth = 8
+        #Jack
+        elif self.worth == 3:
+            self.worth = 13
+        #Queen
+        elif self.worth == 4:
+            self.worth = 9
+        #King
+        elif self.worth == 5:
+            self.worth = 10
+        #Ace
+        elif self.worth == 6:
+            self.worth = 11
+    
+    def set_left(self, trump_suit):
+        self.worth = 12
+        self.is_trump = True
+        self.is_left = True
+        self.suit = trump_suit
 
-	def set_left(self):
-		self.worth = 12
-		self.is_trump = True
-		self.is_left = True
+    def get_is_trump(self):
+        return self.is_trump
 
-	def get_is_trump(self):
-		return self.is_trump
+    def get_is_left(self):
+        return self.is_left
 
-	def get_is_left(self):
-		return self.is_left
+    def get_worth(self):
+        return self.worth
 
-	def get_worth(self):
-		return self.worth
-
-	def set_worth(self,worth):
-		self.worth = worth
+    def set_worth(self,worth):
+        self.worth = worth

--- a/Display.py
+++ b/Display.py
@@ -1,471 +1,462 @@
 import pygame
 
 class Display:
-
-	def __init__(self):
-
-		#Initialize game and display
-		pygame.init()
-		pygame.display.init()
-
-		screen_info = pygame.display.Info() #Required to set a good resolution for the game screen
-		self.width,self.height = 1280,720
-		self.display = pygame.display.set_mode((self.width,self.height))
-		self.announcement_rect = pygame.Rect(20,20,self.width//10,self.height//10)
-		self.score_rect = pygame.Rect(self.width-150,20,self.width//10,self.height//10)
-		self.table_rect = pygame.Rect(self.width//4,self.height//6,self.width//2,self.height//2)
-		self.button_rect = (self.width//20,self.height//10*2)
-		self.suit_rects = [(self.width//20,self.height//10*3),(self.width//20,self.height//10*4), \
-							(self.width//20,self.height//10*5),(self.width//20,self.height//10*6)]
-		self.trick_score_center = (self.width//2,self.height//20)
-		self.rects = 'To_be_set'
-		self.button_rect_actual = 'To_bet_set'
-
-		#Create main surface (display) and set Window title
-		pygame.display.set_caption('EuchreAI')
-
-	def update(self,rects):
-		self.pump()
-		pygame.display.update(rects)
-
-	def flip(self):
-		self.pump()
-		pygame.display.flip()
-
-	def blit(self,surf,dest):
-		self.display.blit(surf,dest)
-
-	def get_height(self):
-		return self.height
-
-	def get_width(self):
-		return self.width
-
-	def get_events(self):
-		return pygame.event.get()
-
-	def prompt_event(self):
-		pygame.event.post(pygame.event.Event(pygame.USEREVENT, {}))
-
-	def user_quit(self):
-		self.prompt_event()
-		for event in pygame.event.get():
-			if event == pygame.QUIT:
-				return True
-			else:
-				return False
-
-	def get_events(self):
-		return pygame.event.get()
-
-	def quit(self):
-		pygame.quit()
-
-	def get_error(self):
-		pygame.get_error()
-
-	def pump(self):
-		pygame.event.pump()
-
-	def wait(self,time):
-		pygame.time.wait(time)
-
-	def update_score(self,score):
-		#Cover area and print score text
-		self.pump()
-		background = pygame.Surface((self.width//3,self.height//10))
-		background.fill((0,128,0))
-		self.display.blit(background,self.score_rect)
-
-		self.pump()
-		font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//60) 
-		text = font.render(f'Team 0: {score[0]}   Team 1: {score[1]}', True, (255,255,255))    
-		self.display.blit(text,self.score_rect) 
-		self.update(self.score_rect)
-
-	def update_team(self,team):
-		self.pump()
-		font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//60) 
-		text = font.render(f'You are on team: {team}', True, (255,255,255))    
-		text_rect = text.get_rect(center = (self.width//2,self.height//60))
-		self.display.blit(text,text_rect) 
-		self.update(text_rect)
-
-	def update_announcement(self,text):
-		#Cover area and print announcement text
-		self.pump()
-		background = pygame.Surface((self.width//3,self.height//10))
-		background.fill((0,128,0))
-		self.display.blit(background,self.announcement_rect)
-
-		self.pump()
-		font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//60) 
-		announcement = font.render(f'{text}', True, (255,255,255))    
-		self.display.blit(announcement,self.announcement_rect) 
-
-		self.update(self.announcement_rect)
-
-	def clear_table(self):
-		image = pygame.image.load('config/card_imgs/wooden_tabletop.jpg').convert_alpha()
-		image.set_alpha(255)
-		image = pygame.transform.smoothscale(image, (self.width//2,self.height//2))
-		self.display.blit(image,self.table_rect)
-		self.update(self.table_rect)
-
-	def display_credit_and_title(self):
-		image = pygame.image.load('config/card_imgs/logo.png').convert_alpha()
-		image = pygame.transform.smoothscale(image, (self.width//10,self.width//10))
-		image_rect = image.get_rect(bottomright = (self.width-10,self.height-10))
-		self.blit(image,image_rect)
-		self.pump()
-		font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//60) 
-		word = font.render('Developed by Patrick Leahey', True, (255,255,255)) 
-		word_rect = word.get_rect(center = (self.get_width()//13,self.get_height()//60*59))
-		self.blit(word, word_rect)
-		self.update([image_rect,word_rect])
-
-	def add_card_to_table(self,img,num,backs):
-			
-		self.pump()
-
-		left_start = self.table_rect.centerx - (2 * self.width//50)
-
-		self.pump()
-
-		if backs:
-			for i in range(num-1):
-				self.pump()
-				image = pygame.image.load('config/card_imgs/back.png').convert_alpha()
-				image = pygame.transform.smoothscale(image, (self.width//9,self.height//3))
-				image_rect = image.get_rect()
-				image_rect.centery = self.table_rect.centery
-				self.pump()
-				image_rect.centerx = left_start + i * self.width//50
-				self.display.blit(image,image_rect)
-				self.pump()
-
-				self.update(image_rect)
-
-		self.pump()
-
-		image = pygame.image.load(img).convert_alpha()
-		image = pygame.transform.smoothscale(image, (self.width//9,self.height//3))
-
-		self.pump()
-
-		image_rect = image.get_rect()
-		image_rect.centery = self.table_rect.centery
-		image_rect.centerx = left_start + num * self.width//50
-		self.display.blit(image,image_rect)
-
-		self.pump()			
-
-		self.update(image_rect)
-
-	def add_text(self,text,rect):
-
-		self.pump()
-		background = pygame.Surface((self.width//50,self.height//50))
-		background.fill((0,128,0))
-		background_rect = background.get_rect(center = rect)
-		self.display.blit(background,background_rect)
-
-		self.pump()
-
-		font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//50) 
-		words = font.render(f'{text}', True, (255,255,255))    
-		words_rect = words.get_rect(center = rect)
-		self.display.blit(words,words_rect) 
-
-		self.pump()
-
-		self.update(words_rect)
-
-	def display_hand(self,hand):
-		self.pump()
-		game_on = True
-		while game_on == True:
-			self.pump()
-			self.prompt_event()
-			for event in self.get_events():
-				if event.type == pygame.QUIT:
-					self.display.quit()
-				else:
-					self.pump()
-
-					background = pygame.Surface((self.get_width()//4*3, self.get_height()//6))
-					background.fill((0,128,0))
-					background_rect = background.get_rect()
-					background_rect.center = (self.get_width()//2,self.get_height()//8*7)
-					self.blit(background,background_rect)
-					self.update(background_rect)
-					self.pump()
-
-					rects = []
-
-					self.pump()
-					for i,card in zip(range(len(hand)),hand):
-						img_path = card.get_img_path()
-						image = pygame.image.load(img_path)
-						image = pygame.transform.smoothscale(image, (self.get_width()//10,self.get_height()//6)).convert_alpha()
-						image_rect = image.get_rect()
-						space = self.get_width()//50
-						start_left = self.get_width()//2 - (2 * space) - (2 * self.get_width()//8)
-						image_rect.center = ((start_left + i * (space + self.get_width()//8)), (self.get_height()//8 * 7))
-
-						self.pump()
-						
-						rects.append(image_rect)
-						self.blit(image,image_rect)
-						self.update(image_rect)
-						self.wait(100)
-
-					self.pump()
-
-					return rects
-
-
-	def set_current(self,player):
-		player_seat = player.get_seat()
-
-		pygame_circ = pygame.draw.circle(self.display,(6, 30, 250),(player_seat[0],player_seat[1] + self.height//35),self.width//120)
-
-	def unset_current(self,player):
-		player_seat = player.get_seat()
-
-		background = pygame.Surface((self.get_width()//30,self.get_height()//30))
-		background.fill((0,128,0))
-		background_rect = background.get_rect()
-		background_rect.center = (player_seat[0],player_seat[1] + self.height//35)
-		self.blit(background,background_rect)
-
-		self.update(background_rect)
-
-	def set_dealer(self,dealer):
-		dealer_seat = dealer.get_seat()
-
-		self.pump()
-
-		font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//45) 
-		words = font.render('DEALER', True, (252,186,3))    
-		words_rect = words.get_rect(center = (dealer_seat[0],dealer_seat[1] - self.height//35))
-		self.display.blit(words,words_rect) 
-
-		self.pump()
-
-		self.update(words_rect)
-
-	def unset_dealer(self,dealer):
-		dealer_seat = dealer.get_seat()
-
-		background = pygame.Surface((self.get_width()//45,self.get_height()//45))
-		background.fill((0,128,0))
-		background_rect = background_rect.get_rect()
-		background_rect.center = (dealer_seat[0],dealer_seat[1] - self.height//35)
-		self.blit(background,background_rect)
-
-		self.update(background_rect)
-
-	def update_trick_score(self,score):
-
-		line = pygame.Surface((2,self.get_height()//30))
-		line.fill((0,0,0))
-		line_rect = line.get_rect(center = self.trick_score_center)
-		self.blit(line,line_rect)
-		self.update(line_rect)
-
-		rects = []
-
-		for i in range(score[0]):
-			pygame_circ = pygame.draw.circle(self.display,(224, 22, 22),(self.trick_score_center[0] - (i+1)  * 45,self.trick_score_center[1]),self.width//120)
-			rects.append(pygame_circ)
-
-		for i in range(score[1]):
-			pygame_circ = pygame.draw.circle(self.display,(224, 22, 22),(self.trick_score_center[0] + (i+1) * 45,self.trick_score_center[1]),self.width//120)
-			rects.append(pygame_circ)
-
-		self.update(rects)
-
-	def cover_suits(self):
-
-		self.pump()
-		background = pygame.Surface((self.width//20,self.height//3*2))
-		background.fill((0,128,0))
-		background_rect = background.get_rect(center = self.suit_rects[2])
-		self.display.blit(background,background_rect)
-		self.update(background_rect)
-		self.pump()
-
-	def update_suit(self,suit):
-		
-		self.pump()
-
-		if suit == 'H':
-			img_path = 'config/card_imgs/heart.png'
-		elif suit == 'D':
-			img_path = 'config/card_imgs/diamond.png'
-		elif suit == 'C':
-			img_path = 'config/card_imgs/club.png'
-		else:
-			img_path = 'config/card_imgs/spade.png'
-
-		self.cover_suits()
-
-		self.pump()
-		image = pygame.image.load(img_path).convert_alpha()
-		image = pygame.transform.smoothscale(image, (self.get_width()//20,self.get_height()//15))
-		image_rect = image.get_rect()
-		image_rect.center = self.button_rect
-
-		self.pump()
-		
-		self.blit(image,image_rect)
-
-		self.update(image_rect)
-
-	def display_suits(self,suits):
-
-		self.cover_suits()
-
-		suit_paths = []
-
-		self.update_announcement('Click on a suit to call it trump')
-
-		self.pump()
-
-		for suit in suits:
-			if suit == 'H':
-				suit_paths.append('config/card_imgs/heart.png')
-			elif suit == 'D':
-				suit_paths.append('config/card_imgs/diamond.png')
-			elif suit == 'C':
-				suit_paths.append('config/card_imgs/club.png')
-			else:
-				suit_paths.append('config/card_imgs/spade.png')
-
-		rects = []
-
-		for i,img_path in zip(range(len(suit_paths)),suit_paths):
-			self.pump()
-			image = pygame.image.load(img_path).convert_alpha()
-			image = pygame.transform.smoothscale(image, (self.get_width()//20,self.get_height()//15))
-			image_rect = image.get_rect()
-			image_rect.center = self.suit_rects[i]
-
-			self.pump()
-			
-			rects.append(image_rect)
-			self.blit(image,image_rect)
-
-		self.update(rects)
-		self.pump()
-
-		#Button
-		button = pygame.Surface((self.get_width()//20,self.get_height()//15))
-		button.fill((255,255,255))
-		button_rect_actual = button.get_rect()
-		button_rect_actual.center = self.button_rect
-		self.blit(button,button_rect_actual)
-
-		self.pump()
-
-		#Button text
-		font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//50) 
-		button_text = font.render('PASS', True, (0,0,0)) 
-		button_text_rect = button_text.get_rect()  
-		button_text_rect.center = self.button_rect
-		self.blit(button_text,button_text_rect) 
-
-		self.pump()
-
-		self.update(button_rect_actual)
-
-		self.rects = rects
-		self.button_rect_actual = button_rect_actual
-
-	def select_suit(self,suits):
-
-		user_clicked = False
-		while user_clicked == False:
-			for event in self.get_events():
-				if event.type == pygame.QUIT:
-					self.quit()
-				elif event.type == pygame.MOUSEBUTTONUP:
-					pos = pygame.mouse.get_pos()
-					if True in [suit_rect.collidepoint(pos) for suit_rect in self.rects]:
-						suit_index = [suit_rect.collidepoint(pos) for suit_rect in self.rects].index(True)
-						selected_suit = suits[suit_index]
-
-						#self.cover_suits()
-
-						self.pump()
-
-						self.update_suit(selected_suit)
-
-						self.pump()
-
-						if selected_suit == 'H':
-							s = 'Hearts'
-						elif selected_suit == 'D':
-							s = 'Diamonds'
-						elif selected_suit == 'C':
-							s = 'Clubs'
-						else:
-							s = 'Spades'
-
-						self.update_announcement(f'You selected {s} as trump')
-						return selected_suit
-
-					if self.button_rect_actual.collidepoint(pos):
-						self.update_announcement('You passed')
-						return ''
-
-	def select_card(self,user,played_so_far):
-
-		self.update_announcement('Click a card to play it')
-
-		user_clicked = False
-		while user_clicked == False:
-			for event in self.get_events():
-
-				if event.type == pygame.QUIT:
-					self.quit()
-				elif event.type == pygame.MOUSEBUTTONUP:
-					
-					pos = pygame.mouse.get_pos()
-		
-					if True in [card_rect.collidepoint(pos) for card_rect in user.get_hand().get_rects()]:
-
-						card_index = [card_rect.collidepoint(pos) for card_rect in user.get_hand().get_rects()].index(True)
-						selected_card = [card for card in user.get_hand().get_cards()][card_index]
-
-						print(selected_card.get_suit())
-
-						#If the user is following 
-						if len(played_so_far) != 0:
-
-							#If trump was led and the user has the left, but didn't play it 
-							if played_so_far[0].get_is_trump() and \
-														selected_card.get_suit() != played_so_far[0].get_suit() and \
-														True in [card.get_is_left() for card in user.get_hand().get_cards()]:
-								self.update_announcement('You must follow suit!')
-
-
-							#If user has card of led suit and didn't play it
-							elif True in [card.get_suit()==played_so_far[0].get_suit() for card in user.get_hand().get_cards()] \
-														and selected_card.get_suit() != played_so_far[0].get_suit():
-								self.update_announcement('You must follow suit!')
-
-							else:
-								user.get_hand().remove_card(selected_card)
-								user.get_hand().remove_rect(card_index)
-								return selected_card
-
-
-
-
-
-
-
-
-						
+    
+    def __init__(self):
+
+        #Initialize game and display
+        pygame.init()
+        pygame.display.init()
+
+        screen_info = pygame.display.Info() #Required to set a good resolution for the game screen
+        self.width,self.height = 1280,720
+        self.display = pygame.display.set_mode((self.width,self.height))
+        self.announcement_rect = pygame.Rect(20,20,self.width//2,self.height//10)
+        self.score_rect = pygame.Rect(self.width-150,20,self.width//10,self.height//10)
+        self.table_rect = pygame.Rect(self.width//4,self.height//6,self.width//2,self.height//2)
+        self.button_rect = (self.width//20,self.height//10*2)
+        self.suit_rects = [(self.width//20,self.height//10*3),(self.width//20,self.height//10*4), \
+                            (self.width//20,self.height//10*5),(self.width//20,self.height//10*6)]
+        self.trick_score_center = (self.width//2,self.height//20)
+        self.rects = 'To_be_set'
+        self.button_rect_actual = 'To_bet_set'
+        
+        #Create main surface (display) and set Window title
+        pygame.display.set_caption('EuchreAI')
+    
+    def update(self,rects):
+        self.pump()
+        pygame.display.update(rects)
+    
+    def flip(self):
+        self.pump()
+        pygame.display.flip()
+    
+    def blit(self,surf,dest):
+        self.display.blit(surf,dest)
+    
+    def get_height(self):
+        return self.height
+    
+    def get_width(self):
+        return self.width
+    
+    def get_events(self):
+        return pygame.event.get()
+    
+    def prompt_event(self):
+        pygame.event.post(pygame.event.Event(pygame.USEREVENT, {}))
+    
+    def user_quit(self):
+        self.prompt_event()
+        for event in pygame.event.get():
+            if event == pygame.QUIT:
+                return True
+            else:
+                return False
+    
+    def get_events(self):
+        return pygame.event.get()
+    
+    def quit(self):
+        pygame.quit()
+    
+    def get_error(self):
+        pygame.get_error()
+    
+    def pump(self):
+        pygame.event.pump()
+    
+    def wait(self,time):
+        pygame.time.wait(time)
+    
+    def update_score(self,score):
+        #Cover area and print score text
+        self.pump()
+        background = pygame.Surface((self.width//3,self.height//10))
+        background.fill((0,128,0))
+        self.display.blit(background,self.score_rect)
+        
+        self.pump()
+        font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//60) 
+        text = font.render(f'Team 0: {score[0]}   Team 1: {score[1]}', True, (255,255,255))    
+        self.display.blit(text,self.score_rect) 
+        
+        self.update(self.score_rect)
+    
+    def update_team(self,team):
+        self.pump()
+        font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//60) 
+        text = font.render(f'You are on team: {team}', True, (255,255,255))    
+        text_rect = text.get_rect(center = (self.width//2,self.height//60))
+        self.display.blit(text,text_rect) 
+        self.update(text_rect)
+    
+    def update_announcement(self,text):
+        #Cover area and print announcement text
+        self.pump()
+        background = pygame.Surface((self.width//3,self.height//10))
+        background.fill((0,128,0))
+        self.display.blit(background,self.announcement_rect)
+        
+        self.pump()
+        font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//60) 
+        announcement = font.render(f'{text}', True, (255,255,255))    
+        self.display.blit(announcement,self.announcement_rect) 
+        
+        self.update(self.announcement_rect)
+    
+    def clear_table(self):
+        image = pygame.image.load('config/card_imgs/wooden_tabletop.jpg').convert_alpha()
+        image.set_alpha(255)
+        image = pygame.transform.smoothscale(image, (self.width//2,self.height//2))
+        self.display.blit(image,self.table_rect)
+        self.update(self.table_rect)
+    
+    def display_credit_and_title(self):
+        image = pygame.image.load('config/card_imgs/logo.png').convert_alpha()
+        image = pygame.transform.smoothscale(image, (self.width//10,self.width//10))
+        image_rect = image.get_rect(bottomright = (self.width-10,self.height-10))
+        self.blit(image,image_rect)
+        self.pump()
+        font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//60) 
+        word = font.render('Developed by Patrick Leahey', True, (255,255,255)) 
+        word_rect = word.get_rect(center = (self.get_width()//13,self.get_height()//60*59))
+        self.blit(word, word_rect)
+        self.update([image_rect,word_rect])
+
+    def add_card_to_table(self,img,num,backs):
+            
+        self.pump()
+
+        left_start = self.table_rect.centerx - (2 * self.width//50)
+
+        self.pump()
+
+        if backs:
+            for i in range(num-1):
+                self.pump()
+                image = pygame.image.load('config/card_imgs/back.png').convert_alpha()
+                image = pygame.transform.smoothscale(image, (self.width//9,self.height//3))
+                image_rect = image.get_rect()
+                image_rect.centery = self.table_rect.centery
+                self.pump()
+                image_rect.centerx = left_start + i * self.width//50
+                self.display.blit(image,image_rect)
+                self.pump()
+
+                self.update(image_rect)
+
+        self.pump()
+
+        image = pygame.image.load(img).convert_alpha()
+        image = pygame.transform.smoothscale(image, (self.width//9,self.height//3))
+
+        self.pump()
+
+        image_rect = image.get_rect()
+        image_rect.centery = self.table_rect.centery
+        image_rect.centerx = left_start + num * self.width//50
+        self.display.blit(image,image_rect)
+
+        self.pump()            
+
+        self.update(image_rect)
+
+    def add_text(self,text,rect):
+
+        self.pump()
+        background = pygame.Surface((self.width//50,self.height//50))
+        background.fill((0,128,0))
+        background_rect = background.get_rect(center = rect)
+        self.display.blit(background,background_rect)
+
+        self.pump()
+
+        font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//50) 
+        words = font.render(f'{text}', True, (255,255,255))    
+        words_rect = words.get_rect(center = rect)
+        self.display.blit(words,words_rect) 
+
+        self.pump()
+
+        self.update(words_rect)
+
+    def display_hand(self,hand):
+        self.pump()
+        game_on = True
+        while game_on == True:
+            self.pump()
+            self.prompt_event()
+            for event in self.get_events():
+                if event.type == pygame.QUIT:
+                    self.display.quit()
+                else:
+                    self.pump()
+
+                    background = pygame.Surface((self.get_width()//4*3, self.get_height()//6))
+                    background.fill((0,128,0))
+                    background_rect = background.get_rect()
+                    background_rect.center = (self.get_width()//2,self.get_height()//8*7)
+                    self.blit(background,background_rect)
+                    self.update(background_rect)
+                    self.pump()
+
+                    rects = []
+
+                    self.pump()
+                    for i,card in zip(range(len(hand)),hand):
+                        img_path = card.get_img_path()
+                        image = pygame.image.load(img_path)
+                        image = pygame.transform.smoothscale(image, (self.get_width()//10,self.get_height()//6)).convert_alpha()
+                        image_rect = image.get_rect()
+                        space = self.get_width()//50
+                        start_left = self.get_width()//2 - (2 * space) - (2 * self.get_width()//8)
+                        image_rect.center = ((start_left + i * (space + self.get_width()//8)), (self.get_height()//8 * 7))
+
+                        self.pump()
+                        
+                        rects.append(image_rect)
+                        self.blit(image,image_rect)
+                        self.update(image_rect)
+                        self.wait(100)
+
+                    self.pump()
+
+                    return rects
+
+
+    def set_current(self,player):
+        player_seat = player.get_seat()
+
+        pygame_circ = pygame.draw.circle(self.display,(6, 30, 250),(player_seat[0],player_seat[1] + self.height//35),self.width//120)
+
+    def unset_current(self,player):
+        player_seat = player.get_seat()
+
+        background = pygame.Surface((self.get_width()//30,self.get_height()//30))
+        background.fill((0,128,0))
+        background_rect = background.get_rect()
+        background_rect.center = (player_seat[0],player_seat[1] + self.height//35)
+        self.blit(background,background_rect)
+
+        self.update(background_rect)
+
+    def set_dealer(self,dealer):
+        dealer_seat = dealer.get_seat()
+
+        self.pump()
+
+        font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//45) 
+        words = font.render('DEALER', True, (252,186,3))    
+        words_rect = words.get_rect(center = (dealer_seat[0],dealer_seat[1] - self.height//35))
+        self.display.blit(words,words_rect) 
+
+        self.pump()
+
+        self.update(words_rect)
+        
+        self.pump()
+
+    def unset_dealer(self,dealer):
+        dealer_seat = dealer.get_seat()
+
+        background = pygame.Surface((self.get_width()//15,self.get_height()//45))
+        background.fill((0,128,0))
+        background_rect = background.get_rect()
+        background_rect.center = (dealer_seat[0],dealer_seat[1] - self.height//35)
+        self.blit(background,background_rect)
+
+        self.update(background_rect)
+
+    def update_trick_score(self,score):
+
+        line = pygame.Surface((2,self.get_height()//30))
+        line.fill((0,0,0))
+        line_rect = line.get_rect(center = self.trick_score_center)
+        self.blit(line,line_rect)
+        self.update(line_rect)
+
+        rects = []
+
+        for i in range(score[0]):
+            pygame_circ = pygame.draw.circle(self.display,(224, 22, 22),(self.trick_score_center[0] - (i+1)  * 45,self.trick_score_center[1]),self.width//120)
+            rects.append(pygame_circ)
+
+        for i in range(score[1]):
+            pygame_circ = pygame.draw.circle(self.display,(224, 22, 22),(self.trick_score_center[0] + (i+1) * 45,self.trick_score_center[1]),self.width//120)
+            rects.append(pygame_circ)
+
+        self.update(rects)
+
+    def cover_suits(self):
+
+        self.pump()
+        background = pygame.Surface((self.width//20,self.height//3*2))
+        background.fill((0,128,0))
+        background_rect = background.get_rect(center = self.suit_rects[2])
+        self.display.blit(background,background_rect)
+        self.update(background_rect)
+        self.pump()
+
+    def update_suit(self,suit):
+        
+        self.pump()
+
+        if suit == 'H':
+            img_path = 'config/card_imgs/heart.png'
+        elif suit == 'D':
+            img_path = 'config/card_imgs/diamond.png'
+        elif suit == 'C':
+            img_path = 'config/card_imgs/club.png'
+        else:
+            img_path = 'config/card_imgs/spade.png'
+
+        self.cover_suits()
+
+        self.pump()
+        image = pygame.image.load(img_path).convert_alpha()
+        image = pygame.transform.smoothscale(image, (self.get_width()//20,self.get_height()//15))
+        image_rect = image.get_rect()
+        image_rect.center = self.button_rect
+
+        self.pump()
+        
+        self.blit(image,image_rect)
+
+        self.update(image_rect)
+
+    def display_suits(self,suits):
+
+        self.cover_suits()
+
+        suit_paths = []
+
+        self.update_announcement('Click on a suit to call it trump')
+
+        self.pump()
+
+        for suit in suits:
+            if suit == 'H':
+                suit_paths.append('config/card_imgs/heart.png')
+            elif suit == 'D':
+                suit_paths.append('config/card_imgs/diamond.png')
+            elif suit == 'C':
+                suit_paths.append('config/card_imgs/club.png')
+            else:
+                suit_paths.append('config/card_imgs/spade.png')
+
+        rects = []
+
+        for i,img_path in zip(range(len(suit_paths)),suit_paths):
+            self.pump()
+            image = pygame.image.load(img_path).convert_alpha()
+            image = pygame.transform.smoothscale(image, (self.get_width()//20,self.get_height()//15))
+            image_rect = image.get_rect()
+            image_rect.center = self.suit_rects[i]
+
+            self.pump()
+            
+            rects.append(image_rect)
+            self.blit(image,image_rect)
+
+        self.update(rects)
+        self.pump()
+
+        #Button
+        button = pygame.Surface((self.get_width()//20,self.get_height()//15))
+        button.fill((255,255,255))
+        button_rect_actual = button.get_rect()
+        button_rect_actual.center = self.button_rect
+        self.blit(button,button_rect_actual)
+
+        self.pump()
+
+        #Button text
+        font = pygame.font.Font(pygame.font.get_default_font(), self.get_height()//50) 
+        button_text = font.render('PASS', True, (0,0,0)) 
+        button_text_rect = button_text.get_rect()  
+        button_text_rect.center = self.button_rect
+        self.blit(button_text,button_text_rect) 
+
+        self.pump()
+
+        self.update(button_rect_actual)
+
+        self.rects = rects
+        self.button_rect_actual = button_rect_actual
+
+    def select_suit(self,suits):
+
+        user_clicked = False
+        while user_clicked == False:
+            for event in self.get_events():
+                if event.type == pygame.QUIT:
+                    self.quit()
+                elif event.type == pygame.MOUSEBUTTONUP:
+                    pos = pygame.mouse.get_pos()
+                    if True in [suit_rect.collidepoint(pos) for suit_rect in self.rects]:
+                        suit_index = [suit_rect.collidepoint(pos) for suit_rect in self.rects].index(True)
+                        selected_suit = suits[suit_index]
+
+                        #self.cover_suits()
+
+                        self.pump()
+
+                        self.update_suit(selected_suit)
+
+                        self.pump()
+
+                        if selected_suit == 'H':
+                            s = 'Hearts'
+                        elif selected_suit == 'D':
+                            s = 'Diamonds'
+                        elif selected_suit == 'C':
+                            s = 'Clubs'
+                        else:
+                            s = 'Spades'
+
+                        self.update_announcement(f'You selected {s} as trump')
+                        return selected_suit
+
+                    if self.button_rect_actual.collidepoint(pos):
+                        self.update_announcement('You passed')
+                        return ''
+    
+    def select_card(self,user,played_so_far):
+        
+        self.update_announcement('Click a card to play it')
+
+        user_clicked = False
+        while user_clicked == False:
+            for event in self.get_events():
+
+                if event.type == pygame.QUIT:
+                    self.quit()
+                elif event.type == pygame.MOUSEBUTTONUP:
+                    
+                    pos = pygame.mouse.get_pos()
+        
+                    if True in [card_rect.collidepoint(pos) for card_rect in user.get_hand().get_rects()]:
+
+                        card_index = [card_rect.collidepoint(pos) for card_rect in user.get_hand().get_rects()].index(True)
+                        selected_card = [card for card in user.get_hand().get_cards()][card_index]
+                        
+                        #If the user is following 
+                        if len(played_so_far) != 0:
+                            
+                            #If user has card of led suit and didn't play it
+                            if True in [card.get_suit()==played_so_far[0].get_suit() for card in user.get_hand().get_cards()] \
+                                                        and selected_card.get_suit() != played_so_far[0].get_suit():
+                                self.update_announcement('You must follow suit!')
+
+                            else:
+                                user.get_hand().remove_card(selected_card)
+                                user.get_hand().remove_rect(card_index)
+                                return selected_card
+                        
+                        ## If the user is leading
+                        else:
+                            user.get_hand().remove_card(selected_card)
+                            user.get_hand().remove_rect(card_index)
+                            return selected_card

--- a/Euchre.py
+++ b/Euchre.py
@@ -8,9 +8,3 @@ import random
 #Wait for button to be clicked before starting game
 game = Game()
 game.create_user()
-
-
-
-
-
-

--- a/Game.py
+++ b/Game.py
@@ -7,773 +7,778 @@ import pygame
 import datetime
 
 class Game:
-	#Instantiate Game Instance
-	def __init__(self):
-		self.game_id = random.randint(1000000,9000000)
-		self.deck = Deck()
-		self.table = Table()
-		self.user = False
-		self.user_player = None
-		self.display = None
-		
-		random.seed(datetime.datetime.now().strftime('%S'))
-
-	def get_players(self):
-		return self.table.get_players()
-
-	def set_teams(self):
-		for i,player in zip(range(4),self.table.get_players()):
-			if i in [0,2]:
-				player.set_team(0) 
-			else:
-				player.set_team(1)
-
-	#We will want to provide the players to the games after the first round
-	def provide_players(self,players):
-		self.table.set_players(players)	
-
-	#Deal the cards to the players
-	#5 cards each
-	def deal(self):
-
-		#GUI version
-		if self.user:
-			self.display.pump()
-			game_on = True
-			while game_on == True:
-
-				self.display.prompt_event()
-
-				for event in self.display.get_events():
-
-					if event.type == pygame.QUIT:
-						self.display.quit()
-
-					else:
-						for player in self.table.get_players():
-							for _ in range(5):
-								player.get_hand().add_card(self.deck.draw_card())
-
-							#Cards you were dealt - display image for each and end while loop
-						rects = self.display.display_hand(self.user_player.get_hand().get_cards())
-						#Add rects to Hand object 
-						self.user_player.get_hand().set_rects(rects)
-						return 
-
-		#Non-GUI version
-		for player in self.table.get_players():
-			for _ in range(5):
-				player.get_hand().add_card(self.deck.draw_card())
-
-	def get_display(self):
-		return self.display
-
-	#Following each round, the dealer rotates up
-	def next_dealer(self):
-		#There will not be a set dealer in the first round
-		#After this point, there should only be one dealer
-		#Dealer rotates up
-
-		dealer_index = 0
-
-		if True in [player.is_dealer() for player in self.table.get_players()]:
-			dealer_index = [player.is_dealer() for player in self.table.get_players()].index(True)
-
-			self.table.get_players()[dealer_index].toggle_dealer()
-			if self.user:
-				self.display.unset_dealer(self.table.get_players()[dealer_index])
-
-			if dealer_index != 3:
-				lead_index = dealer_index + 1
-				self.table.get_players()[lead_index].toggle_dealer()
-				if lead_index != 3:
-					self.table.set_first(self.table.get_players()[lead_index])
-				else:
-					self.table.set_first(self.table.get_players()[0])
-
-			else:
-				self.table.get_players()[0].toggle_dealer()
-				self.table.set_first(self.table.get_players()[1])
-		else:
-
-			#Random first dealer
-			deal = random.randint(0,3)
-			first = 0 if deal == 3 else deal + 1
-
-			self.table.get_players()[deal].toggle_dealer()
-			self.table.set_first(self.table.get_players()[first])
-
-		if self.user:
-			#If user is dealer
-			if self.table.get_players()[[player.is_dealer() for player in self.table.get_players()].index(True)].get_is_user():
-				self.display.update_announcement('You are now dealer')
-			else:
-				dealer_name = self.table.get_players()[[player.is_dealer() for player in self.table.get_players()].index(True)].get_name()
-				self.display.update_announcement(f'{dealer_name} is now dealer')
-
-		dealer = self.table.get_players()[[player.is_dealer() for player in self.table.get_players()].index(True)]
-		if self.user:
-			self.display.set_dealer(dealer)
-
-		return dealer_index
-		
-	#A trick involves 4 cards
-	def play_trick(self):
-
-		#GUI version
-		if self.user:
-			self.display.pump()
-			game_on = True
-			while game_on == True:
-
-				self.display.prompt_event()
-
-				for event in self.display.get_events():
-
-					if event.type == pygame.QUIT:
-						self.display.quit()
-
-					else:
-
-						#Each player will get a chance to lay down a card, in order
-						#The first time, the player after the dealer will lead
-						#THEN, the winner of the previous trick will lead
-
-						#This list keeps track of the cards played so far so that the player will know to follow suit and what needs to be beaten
-						played_so_far = []
-
-						for player in self.table.get_players():
-
-							#If the player's teammate went alone, skip their turn
-							#Otherwise, do the following
-							if True not in [p.get_went_alone() for p in self.table.get_players() if player.get_team() == p.get_team()] \
-								and not self.user_player.get_went_alone():
-
-								self.display.set_current(player)
-
-								if player == self.user_player:
-									if not played_so_far:
-										self.display.update_announcement("It's your turn to lead")
-
-									played_so_far.append(self.display.select_card(self.user_player,played_so_far))
-									self.display.add_card_to_table(played_so_far[-1].get_img_path(),len(played_so_far),False)
-									self.display.display_hand(self.user_player.get_hand().get_cards())
-								
-								else:
-									played_so_far.append(player.play_card(played_so_far))
-						
-									self.display.update_announcement(f"Player {player.get_name()} played {played_so_far[-1].get_value()} of {played_so_far[-1].get_suit()}'s")
-									self.display.add_card_to_table(played_so_far[-1].get_img_path(),len(played_so_far),False)
-									
-									self.display.wait(750)
-
-								self.display.unset_current(player)
-
-
-						#Generate score of format score = [0,1] or [1,0] as only one team can win
-						#We will optimize for team win rather than individual win because the goal of the game is for the team to win
-						score = []
-
-						#The winning card is the highest worth card contingent upon the fact that the card follows suit or is trump
-						leading_suit = played_so_far[0].get_suit()
-						for played_card in played_so_far:
-							if played_card.get_suit() != leading_suit:
-								if not played_card.get_is_trump():
-									played_card.set_worth(0)
-
-						card_values = [card.get_worth() for card in played_so_far]
-						winning_value = sorted(card_values, reverse = True)[0]
-						winning_card = played_so_far[card_values.index(winning_value)]
-
-						#We want to let the winner of the trick lead the next trick
-						#We need to get the player that won the trick to do this
-						#We need to find out if anyone went alone to help us not misidentify the winning player
-						partner_went_alone_index = None
-
-						for player,i in zip(self.table.get_players(),range(len(self.table.get_players()))):
-							if player.get_went_alone():
-								if i == 0:
-									partner_went_alone_index = 2
-								elif i == 1:
-									partner_went_alone_index = 3
-								elif i == 2:
-									partner_went_alone_index = 0
-								else:
-									partner_went_alone_index = 1
-
-						winner_index = played_so_far.index(winning_card)
-
-						if partner_went_alone_index == None:
-							#Partner did not go alone
-							#Set winner of trick first for next round
-							self.table.set_first(self.table.get_players()[winner_index])
-						else:
-							#Partner went alone
-							#Set winner of trick first for next round
-							#We account for the missing card by adding 1
-							if winner_index >= partner_went_alone_index:
-								self.table.set_first(self.table.get_players()[winner_index+1])
-							else:
-								self.table.set_first(self.table.get_players()[winner_index])
-
-						winning_team = None
-						if played_so_far.index(winning_card) in [0,2]:
-							winning_team = self.table.get_players()[0].get_team()
-						else:
-							winning_team = self.table.get_players()[1].get_team()
-
-						if self.user:
-							self.display.update_announcement(f'Team {winning_team} won the trick!')
-							self.display.wait(750)
-
-						if winning_team == 0:
-							score = [1,0]
-						else:
-							score = [0,1]
-
-						#Add points to player score 
-						for player in self.table.get_players():
-							player.add_to_player_score(score[player.get_team()])
-
-						self.display.clear_table()
-						return score
-
-		#Non-GUI version
-		else:
-
-			#Each player will get a chance to lay down a card, in order
-			#The first time, the player after the dealer will lead
-			#THEN, the winner of the previous trick will lead
-
-			#This list keeps track of the cards played so far so that the player will know to follow suit and what needs to be beaten
-			played_so_far = []
-
-			for player in self.table.get_players():
-
-				#If the player's teammate went alone, skip their turn
-				#Otherwise, do the following
-				if True not in [p.get_went_alone() for p in self.table.get_players() if player.get_team() == p.get_team()]:
-					played_so_far.append(player.play_card(played_so_far))
-
-			#Generate score of format score = [0,1] or [1,0] as only one team can win
-			#We will optimize for team win rather than individual win because the goal of the game is for the team to win
-			score = []
-
-			#The winning card is the highest worth card contingent upon the fact that the card follows suit or is trump
-			leading_suit = played_so_far[0].get_suit()
-			for played_card in played_so_far:
-				if played_card.get_suit() != leading_suit:
-					if not played_card.get_is_trump():
-						played_card.set_worth(0)
-
-			card_values = [card.get_worth() for card in played_so_far]
-			winning_value = sorted(card_values, reverse = True)[0]
-			winning_card = played_so_far[card_values.index(winning_value)]
-			winning_team = 'NA'
-			if played_so_far.index(winning_card) in [0,2]:
-				winning_team = self.table.get_players()[0].get_team()
-			else:
-				winning_team = self.table.get_players()[1].get_team()
-
-			if winning_team == 0:
-				score = [1,0]
-			else:
-				score = [0,1]
-
-			#Add points to player score 
-			for player in self.table.get_players():
-				player.add_to_player_score(score[player.get_team()])
-
-			return score
-
-	#A round involves 20 cards and is equal to 5 tricks
-	#Teams can receive 1, 2, or 4 points for each team
-	def play_round(self):
-		if self.user:
-
-			game_on = True
-			while game_on == True:
-				self.display.prompt_event()
-
-				for event in self.display.get_events():
-					if event.type == pygame.QUIT:
-						self.display.quit()
-
-					else:
-						
-						#Initial deal of cards
-						dealer_index = self.next_dealer()
-						self.deal()
-
-						self.display.pump()
-						#Remainder of cards in self.deck (4) are the kitty -- select the card on top
-						flipped_card = self.deck.get_cards()[3]
-
-						self.display.pump()
-
-						self.display.add_card_to_table(flipped_card.get_img_path(),4,True)
-
-						self.display.pump()
-
-						self.display.update_announcement('Dealer has dealt!')
-
-						trump_suit = ''
-						dealer_team = ''
-
-						#First roound betting
-						picked_up = False
-						picked_up_round = ''
-
-						self.display.display_suits(flipped_card.get_suit())
-
-						for player in self.table.get_players():
-							self.display.set_current(player)
-
-							#Which team is dealing - we want to be able to tell this information to the players when they're betting
-							dealer_team = [player.get_team() for player in self.table.get_players() if player.is_dealer()][0]
-
-							if player == self.user_player:
-								bet = self.display.select_suit(flipped_card.get_suit())
-								
-							else:
-								bet = player.bet(flipped_card,dealer_team,0)
-
-								if bet != '':
-									if bet == 'H':
-										s = 'Hearts'
-									elif bet == 'D':
-										s = 'Diamonds'
-									elif bet == 'C':
-										s = 'Clubs'
-									else:
-										s = 'Spades'
-
-									self.display.update_announcement(f'Player {player.get_name()} chose {s} as trump suit for team {player.get_team()}')
-									self.display.wait(1000)
-
-							if bet != '':
-								picked_up = True
-								picked_up_round = 0
-								trump_suit = flipped_card.get_desc()[0]
-								self.display.update_suit(trump_suit)
-								self.display.unset_current(player)
-
-								break
-
-							else:
-								if self.user:
-									self.display.update_announcement(f'Player {player.get_name()} passed')
-									self.display.unset_current(player)
-									self.display.wait(1000)
-
-						#Second round betting
-						if picked_up == False:
-							self.display.clear_table()
-
-							all_suits = ['H','D','C','S']
-							all_suits.remove(flipped_card.get_suit())
-
-							self.display.display_suits(all_suits)
-
-							for player in self.table.get_players():
-								self.display.set_current(player)
-
-								if player == self.user_player:
-									bet = self.display.select_suit(all_suits)
-								
-								else:
-									bet = player.bet(flipped_card,dealer_team,1)
-
-									if bet != '':
-										if bet == 'H':
-											s = 'Hearts'
-										elif bet == 'D':
-											s = 'Diamonds'
-										elif bet == 'C':
-											s = 'Clubs'
-										else:
-											s = 'Spades'
-
-										self.display.wait(1000)
-										self.display.update_announcement(f'Player {player.get_name()} chose {s} as trump suit for team {player.get_team()}')
-										
-
-								if bet != '':
-									self.display.clear_table()
-									picked_up = True
-									trump_suit = bet
-									self.display.update_suit(trump_suit)
-									self.display.unset_current(player)
-
-									break
-								else:
-									if self.user:
-										self.display.wait(1000)
-										self.display.update_announcement(f'Player {player.get_name()} passed')
-										self.display.unset_current(player)
-
-
-						if trump_suit != '':
-							self.display.clear_table()
-							for player in self.table.get_players():
-								player.get_hand().set_trump(trump_suit)
-
-							if picked_up_round == 0:
-								#Dealer drops one of their cards
-								#Dealer picks up flipped card
-								dealer_index = [player.is_dealer() for player in self.table.get_players()].index(True)
-								#Dealer decide which card to drop -- their worst card unless the flipped card is worse than all
-								dealer_cards = self.table.get_players()[dealer_index].get_hand().get_cards()
-								dealer_card_vals = [card.get_worth() for card in dealer_cards]
-								dealer_worst_card = sorted(dealer_card_vals)[0]
-								remove_card = dealer_cards[dealer_card_vals.index(dealer_worst_card)]
-								if flipped_card.get_worth() + 6 < remove_card.get_worth():
-									remove_card = flipped_card
-								self.table.get_players()[dealer_index].get_hand().add_card(flipped_card)
-								self.table.get_players()[dealer_index].get_hand().remove_card(remove_card)
-
-							score = [0,0]
-							for _ in range(5):
-								score0,score1 = self.play_trick()
-								score[0] = score[0] + score0
-								score[1] = score[1] + score1
-								self.display.update_trick_score(score)
-							
-							#Score based on number of tricks won
-
-							#Need to know this so we can see if a team got euchred or not
-							#And whether one player went alone
-							team_called_trump = 'NA'
-							went_alone = 'NA'
-							for player in self.table.get_players():
-								if player.get_called_trump():
-									team_called_trump = player.get_team()
-									if player.get_went_alone():
-										went_alone = player.get_team()
-
-
-							self.display.update_trick_score([0,0])
-
-							if score[0] > score[1]:
-								if self.user:
-									self.display.update_announcement('Team 0 won this round')
-									
-								if score[0] == 5:
-									if self.user:
-										self.display.update_announcement('Team 0 won all 5')
-										
-									return [2,0]
-								elif team_called_trump == 1:
-									if self.user:
-										self.display.update_announcement('Team 0 euchred Team 1')
-										
-									return [2,0]
-								elif went_alone == 0 and score[0] == 5:
-									if self.user:
-										self.display.update_announcement('Team 0 went alone and won all 5')
-										
-									return [4,0]
-								else: 
-									return [1,0]
-
-							else:
-								if self.user:
-									self.display.update_announcement('Team 1 won this round')
-									
-								if score[1] == 5:
-									if self.user:
-										self.display.update_announcement('Team 1 won all 5')
-
-									return [0,2]
-								elif team_called_trump == 0:
-									if self.user:
-										self.display.update_announcement('Team 1 euchred Team 0')
-
-									return [0,2]
-								elif went_alone == 1 and score[1] == 5:
-									if self.user:
-										self.display.update_announcement('Team 1 went alone and won all 5')
-
-									return [0,4]
-								else: 
-
-									return [0,1]
-							
-						#The suit was not set during betting
-						else:
-							if self.user:
-								self.display.update_announcement('Neither team wanted to bet')
-								
-							return [0,0]
-		else:
-
-			#Initial deal of cards
-			dealer_index = self.next_dealer()
-			self.deal()
-
-			#Remainder of cards in self.deck (4) are the kitty -- select the card on top
-			flipped_card = self.deck.get_cards()[3]
-
-			trump_suit = ''
-			dealer_team = ''
-
-			#First roound betting
-			picked_up = False
-			picked_up_round = ''
-
-			for player in self.table.get_players():
-				#Which team is dealing - we want to be able to tell this information to the players when they're betting
-				dealer_team = [player.get_team() for player in self.table.get_players() if player.is_dealer()][0]
-
-				bet = player.bet(flipped_card,dealer_team,0)
-				if bet != '':
-					picked_up = True
-					picked_up_round = 0
-					trump_suit = flipped_card.get_desc()[0]
-					break
-
-			#Second round betting
-			if picked_up == False:
-				for player in self.table.get_players():
-					bet = player.bet(flipped_card,dealer_team,1)
-					if bet != '':
-						picked_up = True
-						trump_suit = bet
-						break
-			
-
-			if trump_suit != '':
-
-				for player in self.table.get_players():
-					player.get_hand().set_trump(trump_suit)
-
-				if picked_up_round == 0:
-					#Dealer drops one of their cards
-					#Dealer picks up flipped card
-					dealer_index = [player.is_dealer() for player in self.table.get_players()].index(True)
-					#Dealer decide which card to drop -- their worst card unless the flipped card is worse than all
-					dealer_cards = self.table.get_players()[dealer_index].get_hand().get_cards()
-					dealer_card_vals = [card.get_worth() for card in dealer_cards]
-					dealer_worst_card = sorted(dealer_card_vals)[0]
-					remove_card = dealer_cards[dealer_card_vals.index(dealer_worst_card)]
-					if flipped_card.get_worth() + 6 < remove_card.get_worth():
-						remove_card = flipped_card
-					self.table.get_players()[dealer_index].get_hand().add_card(flipped_card)
-					self.table.get_players()[dealer_index].get_hand().remove_card(remove_card)
-
-				score = [0,0]
-				for _ in range(5):
-					score0,score1 = self.play_trick()
-					score[0] = score[0] + score0
-					score[1] = score[1] + score1
-				
-				#Score based on number of tricks won
-
-				#Need to know this so we can see if a team got euchred or not
-				#And whether one player went alone
-				team_called_trump = None
-				went_alone = None
-				for player in self.table.get_players():
-					if player.get_called_trump():
-						team_called_trump = player.get_team()
-						if player.get_went_alone():
-							went_alone = player.get_team()
-
-
-				if score[0] > score[1]:
-					if score[0] == 5:
-						return [2,0]
-					elif team_called_trump == 1:
-						return [2,0]
-					elif went_alone == 0 and score[0] == 5:
-						return [4,0]
-					else: 
-						return [1,0]
-
-				else:
-					if score[1] == 5:
-						return [0,2]
-					elif team_called_trump == 0:
-						return [0,2]
-					elif went_alone == 1 and score[1] == 5:
-						return [0,4]
-					else: 
-						return [0,1]
-				
-			#The suit was not set during betting
-			else:
-				return [0,0]
-
-	#A game is over when one team reaches 10 points
-	def play_game(self):
-
-		if self.user:
-
-			self.display.pump()
-
-			score = [0,0]
-			num_round = 1
-
-			game_on = True
-			while score[0] < 10 and score[1] < 10 and game_on == True:
-
-				self.display.prompt_event()
-				for event in self.display.get_events():
-					if event.type == pygame.QUIT:
-						self.display.quit()
-
-					else:
-						round_score = self.play_round()
-
-						score = [score[0] + round_score[0], score[1] + round_score[1]]
-
-						if self.user:
-							self.display.update_announcement(f'End of round number {num_round}')
-							self.display.update_score(score)
-	
-						self.deck = Deck()
-						for player in self.table.get_players():
-							player.reset_hand()
-
-							if player.is_dealer():
-								player.toggle_dealer()
-
-							if player.get_called_trump():
-								player.toggle_called_trump()
-
-								if player.get_went_alone():
-									player.toggle_went_alone()
-
-						num_round = num_round + 1
-						self.display.update_score([0,0])
-
-
-			winner_number = 0 if score[0] > score[1] else 1
-			
-			self.display.update_announcement(f'GAME OVER! Team {winner_number} is victorious!')
-
-
-		#If there is no user
-		else:
-			score = [0,0]
-			num_round = 1
-			while score[0] < 10 and score[1] < 10:
-				round_score = self.play_round()
-
-				score = [score[0] + round_score[0], score[1] + round_score[1]]
-
-				self.deck = Deck()
-				for player in self.table.get_players():
-					player.reset_hand()
-
-					if player.is_dealer():
-						player.toggle_dealer()
-
-					if player.get_called_trump():
-						player.toggle_called_trump()
-
-						if player.get_went_alone():
-							player.toggle_went_alone()
-
-				num_round = num_round + 1
-
-	def create_user(self):
-		self.user = True
-		self.user_player = self.table.get_players()[2]
-		self.display = Display()
-
-		seats = [(int(self.display.get_width()//2),int(self.display.get_height()//9)), \
-			(int(self.display.get_width()//10*8.5),int(self.display.get_height()//2.4)), \
-			(int(self.display.get_width()//2),int(self.display.get_height()//10*7.3)), \
-			(int(self.display.get_width()//10*1.5),int(self.display.get_height()//2.4))]
-
-		self.display.pump()
-
-		#Give players fun names
-		names = []
-		for i,player in zip(range(4),self.table.get_players()):
-			named = False
-			player.set_seat(seats[i])
-			while named == False:
-				name = random.choice(con.names)
-				if name not in names:
-					player.set_name(name)
-					names.append(name)
-					named = True
-
-		self.display.pump()
-
-		background = pygame.Surface((self.display.get_width(),self.display.get_height()))
-		background.fill((0,128,0))
-		background_rect = background.get_rect()
-		background_rect.center = (self.display.get_width()//2,self.display.get_height()//2)
-		self.display.blit(background,background_rect)
-		self.display.flip()
-
-		rects = []
-
-		#Create title text 'EuchreAI'
-		font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//12) 
-		text = font.render('EuchreAI', True, (255,255,255)) 
-		text_rect = text.get_rect()  
-		text_rect.center = (self.display.get_width()//2,self.display.get_height()//12) 
-		self.display.blit(text,text_rect) 
-		rects.append(text_rect)
-
-		#Image
-		image = pygame.image.load('config/card_imgs/title_img.png')
-		image = pygame.transform.smoothscale(image, (self.display.get_width()//2,self.display.get_height()//2)).convert_alpha()
-		image_rect = image.get_rect()
-		image_rect.center = (self.display.get_width()//2,self.display.get_height()//2)
-		self.display.blit(image,image_rect)
-		rects.append(image_rect)
-
-		#Button
-		button = pygame.Surface((self.display.get_width()//5,self.display.get_height()//12))
-		button.fill((245,245,245))
-		button_rect = button.get_rect()
-		button_rect.center = (self.display.get_width()//2,self.display.get_height()//10*9)
-		self.display.blit(button,button_rect)
-		rects.append(button_rect)
-
-		#Button text
-		font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//12) 
-		button_text = font.render('PLAY', True, (0,0,0)) 
-		button_text_rect = button_text.get_rect()  
-		button_text_rect.center = button_rect.center
-		self.display.blit(button_text,button_text_rect) 
-		rects.append(button_text_rect)
-
-		self.display.display_credit_and_title()
-
-		#Update specific rectangles
-		self.display.update(rects)
-
-		game_on = True
-
-		while game_on == True:
-			self.display.prompt_event()
-			for event in self.display.get_events():
-				if event.type == pygame.QUIT:
-					self.display.quit()
-				elif event.type == pygame.MOUSEBUTTONUP:
-					pos = pygame.mouse.get_pos()
-					if button_rect.collidepoint(pos):
-						background = pygame.Surface((self.display.get_width(),self.display.get_height()))
-						background.fill((0,128,0))
-						background_rect = background.get_rect()
-						background_rect.center = (self.display.get_width()//2,self.display.get_height()//2)
-						self.display.blit(background,background_rect)
-						self.display.display_credit_and_title()
-						self.display.flip()
-						self.display.clear_table()
-						self.user_player.set_is_user()
-						for player in self.table.get_players():
-							self.display.add_text(player.get_name(),player.get_seat())
-						self.display.update_announcement('Welcome to EuchreAI! Goodluck!')
-						self.display.update_score([0,0])
-						self.display.update_team(self.user_player.get_team())
-
-
-						self.play_game()
+    #Instantiate Game Instance
+    def __init__(self):
+        self.game_id = random.randint(1000000,9000000)
+        self.deck = Deck()
+        self.table = Table()
+        self.user = False
+        self.user_player = None
+        self.display = None
+        
+        random.seed(datetime.datetime.now().strftime('%S'))
+
+    def get_players(self):
+        return self.table.get_players()
+
+    def set_teams(self):
+        for i,player in zip(range(4),self.table.get_players()):
+            if i in [0,2]:
+                player.set_team(0) 
+            else:
+                player.set_team(1)
+
+    #We will want to provide the players to the games after the first round
+    def provide_players(self,players):
+        self.table.set_players(players)    
+
+    #Deal the cards to the players
+    #5 cards each
+    def deal(self):
+
+        #GUI version
+        if self.user:
+            self.display.pump()
+            game_on = True
+            while game_on == True:
+
+                self.display.prompt_event()
+                
+                for event in self.display.get_events():
+
+                    if event.type == pygame.QUIT:
+                        self.display.quit()
+
+                    else:
+                        for player in self.table.get_players():
+                            for i in range(5):
+                                player.get_hand().add_card(self.deck.draw_card())
+                        
+                        #Cards you were dealt - display image for each and end while loop
+                        rects = self.display.display_hand(self.user_player.get_hand().get_cards())
+                        #Add rects to Hand object 
+                        self.user_player.get_hand().set_rects(rects)
+                        return
+        
+        #Non-GUI version
+        for player in self.table.get_players():
+            for _ in range(5):
+                player.get_hand().add_card(self.deck.draw_card())
+
+    def get_display(self):
+        return self.display
+
+    def next_dealer(self):
+        #Following each round, the dealer rotates up
+        #There will not be a set dealer in the first round
+        #After this point, there should only be one dealer
+        #Dealer rotates up
+        
+        dealer_index = 0
+        
+        if True in [player.is_dealer() for player in self.table.get_players()]:
+            dealer_index = [player.is_dealer() for player in self.table.get_players()].index(True)
+            
+            self.table.get_players()[dealer_index].toggle_dealer()
+            if self.user:
+                self.display.pump()
+                self.display.unset_dealer(self.table.get_players()[dealer_index])
+                self.display.pump()
+
+            if dealer_index != 3:
+                lead_index = dealer_index + 1
+                self.table.get_players()[lead_index].toggle_dealer()
+                if lead_index != 3:
+                    self.table.set_first(self.table.get_players()[lead_index])
+                else:
+                    self.table.set_first(self.table.get_players()[0])
+
+            else:
+                self.table.get_players()[0].toggle_dealer()
+                self.table.set_first(self.table.get_players()[1])
+        else:
+
+            #Random first dealer
+            deal = random.randint(0,3)
+            first = 0 if deal == 3 else deal + 1
+            
+            self.table.get_players()[deal].toggle_dealer()
+            self.table.set_first(self.table.get_players()[first])
+        
+        if self.user:
+            #If user is dealer
+            if self.table.get_players()[[player.is_dealer() for player in self.table.get_players()].index(True)].get_is_user():
+                self.display.update_announcement('You are now dealer')
+            else:
+                dealer_name = self.table.get_players()[[player.is_dealer() for player in self.table.get_players()].index(True)].get_name()
+                self.display.update_announcement(f'{dealer_name} is now dealer')
+        
+        dealer = self.table.get_players()[[player.is_dealer() for player in self.table.get_players()].index(True)]
+        if self.user:
+            self.display.set_dealer(dealer)
+        
+        return dealer_index
+        
+    #A trick involves 4 cards
+    def play_trick(self):
+
+        #GUI version
+        if self.user:
+            self.display.pump()
+            game_on = True
+            while game_on == True:
+
+                self.display.prompt_event()
+
+                for event in self.display.get_events():
+
+                    if event.type == pygame.QUIT:
+                        self.display.quit()
+
+                    else:
+
+                        #Each player will get a chance to lay down a card, in order
+                        #The first time, the player after the dealer will lead
+                        #THEN, the winner of the previous trick will lead
+
+                        #This list keeps track of the cards played so far so that the player will know to follow suit and what needs to be beaten
+                        played_so_far = []
+
+                        for player in self.table.get_players():
+
+                            #If the player's teammate went alone, skip their turn
+                            #Otherwise, do the following
+                            if True not in [p.get_went_alone() for p in self.table.get_players() if player.get_team() == p.get_team()] \
+                                and not self.user_player.get_went_alone():
+
+                                self.display.set_current(player)
+
+                                if player == self.user_player:
+                                    if not played_so_far:
+                                        self.display.update_announcement("It's your turn to lead")
+
+                                    played_so_far.append(self.display.select_card(self.user_player,played_so_far))
+                                    self.display.add_card_to_table(played_so_far[-1].get_img_path(),len(played_so_far),False)
+                                    self.display.display_hand(self.user_player.get_hand().get_cards())
+                                
+                                else:
+                                    played_so_far.append(player.play_card(played_so_far))
+                        
+                                    self.display.update_announcement(f"Player {player.get_name()} played {played_so_far[-1].get_value()} of {played_so_far[-1].get_suit()}'s")
+                                    self.display.add_card_to_table(played_so_far[-1].get_img_path(),len(played_so_far),False)
+                                    
+                                    self.display.wait(750)
+
+                                self.display.unset_current(player)
+
+
+                        #Generate score of format score = [0,1] or [1,0] as only one team can win
+                        #We will optimize for team win rather than individual win because the goal of the game is for the team to win
+                        score = []
+
+                        #The winning card is the highest worth card contingent upon the fact that the card follows suit or is trump
+                        leading_suit = played_so_far[0].get_suit()
+                        for played_card in played_so_far:
+                            if played_card.get_suit() != leading_suit:
+                                if not played_card.get_is_trump():
+                                    played_card.set_worth(0)
+
+                        card_values = [card.get_worth() for card in played_so_far]
+                        winning_value = sorted(card_values, reverse = True)[0]
+                        winning_card = played_so_far[card_values.index(winning_value)]
+
+                        #We want to let the winner of the trick lead the next trick
+                        #We need to get the player that won the trick to do this
+                        #We need to find out if anyone went alone to help us not misidentify the winning player
+                        partner_went_alone_index = None
+
+                        for player,i in zip(self.table.get_players(),range(len(self.table.get_players()))):
+                            if player.get_went_alone():
+                                if i == 0:
+                                    partner_went_alone_index = 2
+                                elif i == 1:
+                                    partner_went_alone_index = 3
+                                elif i == 2:
+                                    partner_went_alone_index = 0
+                                else:
+                                    partner_went_alone_index = 1
+
+                        winner_index = played_so_far.index(winning_card)
+
+                        if partner_went_alone_index == None:
+                            #Partner did not go alone
+                            #Set winner of trick first for next round
+                            self.table.set_first(self.table.get_players()[winner_index])
+                        else:
+                            #Partner went alone
+                            #Set winner of trick first for next round
+                            #We account for the missing card by adding 1
+                            if winner_index >= partner_went_alone_index:
+                                self.table.set_first(self.table.get_players()[winner_index+1])
+                            else:
+                                self.table.set_first(self.table.get_players()[winner_index])
+
+                        winning_team = None
+                        if played_so_far.index(winning_card) in [0,2]:
+                            winning_team = self.table.get_players()[0].get_team()
+                        else:
+                            winning_team = self.table.get_players()[1].get_team()
+
+                        if self.user:
+                            self.display.update_announcement(f'Team {winning_team} won the trick!')
+                            self.display.wait(750)
+
+                        if winning_team == 0:
+                            score = [1,0]
+                        else:
+                            score = [0,1]
+
+                        #Add points to player score 
+                        for player in self.table.get_players():
+                            player.add_to_player_score(score[player.get_team()])
+
+                        self.display.clear_table()
+                        return score
+
+        #Non-GUI version
+        else:
+
+            #Each player will get a chance to lay down a card, in order
+            #The first time, the player after the dealer will lead
+            #THEN, the winner of the previous trick will lead
+
+            #This list keeps track of the cards played so far so that the player will know to follow suit and what needs to be beaten
+            played_so_far = []
+
+            for player in self.table.get_players():
+
+                #If the player's teammate went alone, skip their turn
+                #Otherwise, do the following
+                if True not in [p.get_went_alone() for p in self.table.get_players() if player.get_team() == p.get_team()]:
+                    played_so_far.append(player.play_card(played_so_far))
+
+            #Generate score of format score = [0,1] or [1,0] as only one team can win
+            #We will optimize for team win rather than individual win because the goal of the game is for the team to win
+            score = []
+
+            #The winning card is the highest worth card contingent upon the fact that the card follows suit or is trump
+            leading_suit = played_so_far[0].get_suit()
+            for played_card in played_so_far:
+                if played_card.get_suit() != leading_suit:
+                    if not played_card.get_is_trump():
+                        played_card.set_worth(0)
+
+            card_values = [card.get_worth() for card in played_so_far]
+            winning_value = sorted(card_values, reverse = True)[0]
+            winning_card = played_so_far[card_values.index(winning_value)]
+            winning_team = 'NA'
+            if played_so_far.index(winning_card) in [0,2]:
+                winning_team = self.table.get_players()[0].get_team()
+            else:
+                winning_team = self.table.get_players()[1].get_team()
+
+            if winning_team == 0:
+                score = [1,0]
+            else:
+                score = [0,1]
+
+            #Add points to player score 
+            for player in self.table.get_players():
+                player.add_to_player_score(score[player.get_team()])
+
+            return score
+
+    #A round involves 20 cards and is equal to 5 tricks
+    #Teams can receive 1, 2, or 4 points for each team
+    def play_round(self):
+        if self.user:
+
+            game_on = True
+            while game_on == True:
+                self.display.prompt_event()
+
+                for event in self.display.get_events():
+                    if event.type == pygame.QUIT:
+                        self.display.quit()
+
+                    else:
+                        
+                        #Initial deal of cards
+                        dealer_index = self.next_dealer()
+                        self.deal()
+
+                        self.display.pump()
+                        #Remainder of cards in self.deck (4) are the kitty -- select the card on top
+                        flipped_card = self.deck.get_cards()[3]
+
+                        self.display.pump()
+
+                        self.display.add_card_to_table(flipped_card.get_img_path(),4,True)
+
+                        self.display.pump()
+
+                        self.display.update_announcement('Dealer has dealt!')
+
+                        trump_suit = ''
+                        dealer_team = ''
+
+                        #First roound betting
+                        picked_up = False
+                        picked_up_round = ''
+
+                        self.display.display_suits(flipped_card.get_suit())
+
+                        for player in self.table.get_players():
+                            self.display.set_current(player)
+
+                            #Which team is dealing - we want to be able to tell this information to the players when they're betting
+                            dealer_team = [player.get_team() for player in self.table.get_players() if player.is_dealer()][0]
+
+                            if player == self.user_player:
+                                bet = self.display.select_suit(flipped_card.get_suit())
+                                
+                            else:
+                                bet = player.bet(flipped_card,dealer_team,0)
+
+                                if bet != '':
+                                    if bet == 'H':
+                                        s = 'Hearts'
+                                    elif bet == 'D':
+                                        s = 'Diamonds'
+                                    elif bet == 'C':
+                                        s = 'Clubs'
+                                    else:
+                                        s = 'Spades'
+
+                                    self.display.update_announcement(f'Player {player.get_name()} chose {s} as trump suit for team {player.get_team()}')
+                                    self.display.wait(1000)
+
+                            if bet != '':
+                                picked_up = True
+                                picked_up_round = 0
+                                trump_suit = flipped_card.get_desc()[0]
+                                self.display.update_suit(trump_suit)
+                                self.display.unset_current(player)
+
+                                break
+
+                            else:
+                                if self.user:
+                                    self.display.update_announcement(f'Player {player.get_name()} passed')
+                                    self.display.unset_current(player)
+                                    self.display.wait(1000)
+
+                        #Second round betting
+                        if picked_up == False:
+                            self.display.clear_table()
+
+                            all_suits = ['H','D','C','S']
+                            all_suits.remove(flipped_card.get_suit())
+
+                            self.display.display_suits(all_suits)
+
+                            for player in self.table.get_players():
+                                self.display.set_current(player)
+
+                                if player == self.user_player:
+                                    bet = self.display.select_suit(all_suits)
+                                
+                                else:
+                                    bet = player.bet(flipped_card,dealer_team,1)
+
+                                    if bet != '':
+                                        if bet == 'H':
+                                            s = 'Hearts'
+                                        elif bet == 'D':
+                                            s = 'Diamonds'
+                                        elif bet == 'C':
+                                            s = 'Clubs'
+                                        else:
+                                            s = 'Spades'
+
+                                        self.display.wait(1000)
+                                        self.display.update_announcement(f'Player {player.get_name()} chose {s} as trump suit for team {player.get_team()}')
+                                        
+
+                                if bet != '':
+                                    self.display.clear_table()
+                                    picked_up = True
+                                    trump_suit = bet
+                                    self.display.update_suit(trump_suit)
+                                    self.display.unset_current(player)
+
+                                    break
+                                else:
+                                    if self.user:
+                                        self.display.wait(1000)
+                                        self.display.update_announcement(f'Player {player.get_name()} passed')
+                                        self.display.unset_current(player)
+
+
+                        if trump_suit != '':
+                            self.display.clear_table()
+                            for player in self.table.get_players():
+                                player.get_hand().set_trump(trump_suit)
+
+                            if picked_up_round == 0:
+                                #Dealer drops one of their cards
+                                #Dealer picks up flipped card
+                                dealer_index = [player.is_dealer() for player in self.table.get_players()].index(True)
+                                #Dealer decide which card to drop -- their worst card unless the flipped card is worse than all
+                                dealer_cards = self.table.get_players()[dealer_index].get_hand().get_cards()
+                                dealer_card_vals = [card.get_worth() for card in dealer_cards]
+                                dealer_worst_card = sorted(dealer_card_vals)[0]
+                                remove_card = dealer_cards[dealer_card_vals.index(dealer_worst_card)]
+                                if flipped_card.get_worth() + 6 < remove_card.get_worth():
+                                    remove_card = flipped_card
+                                self.table.get_players()[dealer_index].get_hand().add_card(flipped_card)
+                                self.table.get_players()[dealer_index].get_hand().remove_card(remove_card)
+
+                            score = [0,0]
+                            for _ in range(5):
+                                score0,score1 = self.play_trick()
+                                score[0] = score[0] + score0
+                                score[1] = score[1] + score1
+                                self.display.update_trick_score(score)
+                            
+                            #Score based on number of tricks won
+
+                            #Need to know this so we can see if a team got euchred or not
+                            #And whether one player went alone
+                            team_called_trump = 'NA'
+                            went_alone = 'NA'
+                            for player in self.table.get_players():
+                                if player.get_called_trump():
+                                    team_called_trump = player.get_team()
+                                    if player.get_went_alone():
+                                        went_alone = player.get_team()
+
+
+                            self.display.update_trick_score([0,0])
+
+                            if score[0] > score[1]:
+                                if self.user:
+                                    self.display.update_announcement('Team 0 won this round')
+                                    
+                                if score[0] == 5:
+                                    if self.user:
+                                        self.display.update_announcement('Team 0 won all 5')
+                                        
+                                    return [2,0]
+                                elif team_called_trump == 1:
+                                    if self.user:
+                                        self.display.update_announcement('Team 0 euchred Team 1')
+                                        
+                                    return [2,0]
+                                elif went_alone == 0 and score[0] == 5:
+                                    if self.user:
+                                        self.display.update_announcement('Team 0 went alone and won all 5')
+                                        
+                                    return [4,0]
+                                else: 
+                                    return [1,0]
+
+                            else:
+                                if self.user:
+                                    self.display.update_announcement('Team 1 won this round')
+                                    
+                                if score[1] == 5:
+                                    if self.user:
+                                        self.display.update_announcement('Team 1 won all 5')
+
+                                    return [0,2]
+                                elif team_called_trump == 0:
+                                    if self.user:
+                                        self.display.update_announcement('Team 1 euchred Team 0')
+
+                                    return [0,2]
+                                elif went_alone == 1 and score[1] == 5:
+                                    if self.user:
+                                        self.display.update_announcement('Team 1 went alone and won all 5')
+
+                                    return [0,4]
+                                else: 
+
+                                    return [0,1]
+                            
+                        #The suit was not set during betting
+                        else:
+                            if self.user:
+                                self.display.update_announcement('Neither team wanted to bet')
+                                
+                            return [0,0]
+        else:
+
+            #Initial deal of cards
+            dealer_index = self.next_dealer()
+            self.deal()
+
+            #Remainder of cards in self.deck (4) are the kitty -- select the card on top
+            flipped_card = self.deck.get_cards()[3]
+
+            trump_suit = ''
+            dealer_team = ''
+
+            #First roound betting
+            picked_up = False
+            picked_up_round = ''
+
+            for player in self.table.get_players():
+                #Which team is dealing - we want to be able to tell this information to the players when they're betting
+                dealer_team = [player.get_team() for player in self.table.get_players() if player.is_dealer()][0]
+
+                bet = player.bet(flipped_card,dealer_team,0)
+                if bet != '':
+                    picked_up = True
+                    picked_up_round = 0
+                    trump_suit = flipped_card.get_desc()[0]
+                    break
+
+            #Second round betting
+            if picked_up == False:
+                for player in self.table.get_players():
+                    bet = player.bet(flipped_card,dealer_team,1)
+                    if bet != '':
+                        picked_up = True
+                        trump_suit = bet
+                        break
+            
+
+            if trump_suit != '':
+
+                for player in self.table.get_players():
+                    player.get_hand().set_trump(trump_suit)
+
+                if picked_up_round == 0:
+                    #Dealer drops one of their cards
+                    #Dealer picks up flipped card
+                    dealer_index = [player.is_dealer() for player in self.table.get_players()].index(True)
+                    #Dealer decide which card to drop -- their worst card unless the flipped card is worse than all
+                    dealer_cards = self.table.get_players()[dealer_index].get_hand().get_cards()
+                    dealer_card_vals = [card.get_worth() for card in dealer_cards]
+                    dealer_worst_card = sorted(dealer_card_vals)[0]
+                    remove_card = dealer_cards[dealer_card_vals.index(dealer_worst_card)]
+                    if flipped_card.get_worth() + 6 < remove_card.get_worth():
+                        remove_card = flipped_card
+                    self.table.get_players()[dealer_index].get_hand().add_card(flipped_card)
+                    self.table.get_players()[dealer_index].get_hand().remove_card(remove_card)
+
+                score = [0,0]
+                for _ in range(5):
+                    score0,score1 = self.play_trick()
+                    score[0] = score[0] + score0
+                    score[1] = score[1] + score1
+                
+                #Score based on number of tricks won
+
+                #Need to know this so we can see if a team got euchred or not
+                #And whether one player went alone
+                team_called_trump = None
+                went_alone = None
+                for player in self.table.get_players():
+                    if player.get_called_trump():
+                        team_called_trump = player.get_team()
+                        if player.get_went_alone():
+                            went_alone = player.get_team()
+
+
+                if score[0] > score[1]:
+                    if score[0] == 5:
+                        return [2,0]
+                    elif team_called_trump == 1:
+                        return [2,0]
+                    elif went_alone == 0 and score[0] == 5:
+                        return [4,0]
+                    else: 
+                        return [1,0]
+
+                else:
+                    if score[1] == 5:
+                        return [0,2]
+                    elif team_called_trump == 0:
+                        return [0,2]
+                    elif went_alone == 1 and score[1] == 5:
+                        return [0,4]
+                    else: 
+                        return [0,1]
+                
+            #The suit was not set during betting
+            else:
+                return [0,0]
+
+    #A game is over when one team reaches 10 points
+    def play_game(self):
+
+        if self.user:
+
+            self.display.pump()
+
+            score = [0,0]
+            team_0_score = 0
+            team_1_score = 0
+            num_round = 1
+
+            game_on = True
+            while team_0_score < 10 and team_1_score < 10 and game_on == True:
+
+                self.display.prompt_event()
+                round_score = self.play_round()
+
+                score = [score[0] + round_score[0], score[1] + round_score[1]]
+                team_0_score += round_score[0]
+                team_1_score += round_score[1]
+                
+                if self.user:
+                    self.display.pump()
+                    
+                    self.display.update_announcement(f'End of round number {num_round}')
+                    
+                    self.display.pump()
+                    print(f"End of round number {num_round}.  Score {score}")
+                    print(f"team_0_score: {team_0_score}")
+                    print(f"team_1_score: {team_1_score}")
+                    
+                    self.display.update_score(score)
+                    
+                    self.display.pump()
+                
+                self.deck = Deck()
+                for player in self.table.get_players():
+                    player.reset_hand()
+                    
+                    if player.get_called_trump():
+                        player.toggle_called_trump()
+
+                        if player.get_went_alone():
+                            player.toggle_went_alone()
+                
+                num_round = num_round + 1
+            
+            winner_number = 0 if score[0] > score[1] else 1
+            
+            self.display.update_announcement(f'GAME OVER! Team {winner_number} is victorious!')
+        
+        #If there is no user
+        else:
+            score = [0,0]
+            num_round = 1
+            while score[0] < 10 and score[1] < 10:
+                round_score = self.play_round()
+
+                score = [score[0] + round_score[0], score[1] + round_score[1]]
+
+                self.deck = Deck()
+                for player in self.table.get_players():
+                    player.reset_hand()
+
+                    if player.is_dealer():
+                        player.toggle_dealer()
+
+                    if player.get_called_trump():
+                        player.toggle_called_trump()
+
+                        if player.get_went_alone():
+                            player.toggle_went_alone()
+
+                num_round = num_round + 1
+
+    def create_user(self):
+        self.user = True
+        self.user_player = self.table.get_players()[2]
+        self.display = Display()
+
+        seats = [(int(self.display.get_width()//2),int(self.display.get_height()//9)), \
+            (int(self.display.get_width()//10*8.5),int(self.display.get_height()//2.4)), \
+            (int(self.display.get_width()//2),int(self.display.get_height()//10*7.3)), \
+            (int(self.display.get_width()//10*1.5),int(self.display.get_height()//2.4))]
+
+        self.display.pump()
+
+        #Give players fun names
+        names = []
+        for i,player in zip(range(4),self.table.get_players()):
+            named = False
+            player.set_seat(seats[i])
+            while named == False:
+                name = random.choice(con.names)
+                if name not in names:
+                    player.set_name(name)
+                    names.append(name)
+                    named = True
+
+        self.display.pump()
+
+        background = pygame.Surface((self.display.get_width(),self.display.get_height()))
+        background.fill((0,128,0))
+        background_rect = background.get_rect()
+        background_rect.center = (self.display.get_width()//2,self.display.get_height()//2)
+        self.display.blit(background,background_rect)
+        self.display.flip()
+
+        rects = []
+
+        #Create title text 'EuchreAI'
+        font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//12) 
+        text = font.render('EuchreAI', True, (255,255,255)) 
+        text_rect = text.get_rect()  
+        text_rect.center = (self.display.get_width()//2,self.display.get_height()//12) 
+        self.display.blit(text,text_rect) 
+        rects.append(text_rect)
+
+        #Image
+        image = pygame.image.load('config/card_imgs/title_img.png')
+        image = pygame.transform.smoothscale(image, (self.display.get_width()//2,self.display.get_height()//2)).convert_alpha()
+        image_rect = image.get_rect()
+        image_rect.center = (self.display.get_width()//2,self.display.get_height()//2)
+        self.display.blit(image,image_rect)
+        rects.append(image_rect)
+
+        #Button
+        button = pygame.Surface((self.display.get_width()//5,self.display.get_height()//12))
+        button.fill((245,245,245))
+        button_rect = button.get_rect()
+        button_rect.center = (self.display.get_width()//2,self.display.get_height()//10*9)
+        self.display.blit(button,button_rect)
+        rects.append(button_rect)
+
+        #Button text
+        font = pygame.font.Font(pygame.font.get_default_font(), self.display.get_height()//12) 
+        button_text = font.render('PLAY', True, (0,0,0)) 
+        button_text_rect = button_text.get_rect()  
+        button_text_rect.center = button_rect.center
+        self.display.blit(button_text,button_text_rect) 
+        rects.append(button_text_rect)
+
+        self.display.display_credit_and_title()
+
+        #Update specific rectangles
+        self.display.update(rects)
+
+        game_on = True
+
+        while game_on == True:
+            self.display.prompt_event()
+            for event in self.display.get_events():
+                if event.type == pygame.QUIT:
+                    self.display.quit()
+                elif event.type == pygame.MOUSEBUTTONUP:
+                    pos = pygame.mouse.get_pos()
+                    if button_rect.collidepoint(pos):
+                        background = pygame.Surface((self.display.get_width(),self.display.get_height()))
+                        background.fill((0,128,0))
+                        background_rect = background.get_rect()
+                        background_rect.center = (self.display.get_width()//2,self.display.get_height()//2)
+                        self.display.blit(background,background_rect)
+                        self.display.display_credit_and_title()
+                        self.display.flip()
+                        self.display.clear_table()
+                        self.user_player.set_is_user()
+                        for player in self.table.get_players():
+                            self.display.add_text(player.get_name(),player.get_seat())
+                        self.display.update_announcement('Welcome to EuchreAI! Good luck!')
+                        self.display.update_score([0,0])
+                        self.display.update_team(self.user_player.get_team())
+
+
+                        self.play_game()
 

--- a/Hand.py
+++ b/Hand.py
@@ -1,48 +1,51 @@
 class Hand:
 
-	def __init__(self):
-		self.cards = []
-		self.rects = []
+    def __init__(self):
+        self.cards = []
+        self.rects = []
 
-	def get_cards(self):
-		return self.cards
+    def get_cards(self):
+        return self.cards
 
-	def add_card(self,card):
-		self.cards.append(card)
+    def add_card(self,card):
+        self.cards.append(card)
 
-	def set_rects(self,rects):
-		self.rects = rects
+    def set_rects(self,rects):
+        self.rects = rects
 
-	def get_rects(self):
-		return self.rects
+    def get_rects(self):
+        return self.rects
 
-	def remove_rect(self,index):
-		print(self.rects)
-		for rect,i in zip(self.rects,range(len(self.rects))):
-			if i > index:
-				self.rects[i-1] = rect
-		self.rects.pop(-1)
-		print(self.rects)
-		
-	def remove_card(self,card):
-		self.cards.remove(card)
+    def remove_rect(self,index):
+        rects_moved = []
+        for rect,i in zip(self.rects,range(len(self.rects))):
+            if i == index:
+                rect_to_remove = self.rects[i]
+            if i > index:
+                if i == index + 1:
+                    rects_moved.append(self.rects[i])
+                    self.rects[i] = rect_to_remove
+                else:
+                    rects_moved.append(self.rects[i])
+                    self.rects[i] = rects_moved[len(rects_moved)-2]
+        self.rects.pop(index)
+        
+    def remove_card(self,card):
+        self.cards.remove(card)
 
-	def set_trump(self,trump_suit):
-		for card in self.get_cards():
-			if card.get_desc()[0] == trump_suit:
-				card.set_trump()
+    def set_trump(self,trump_suit):
+        for card in self.get_cards():
+            if card.get_desc()[0] == trump_suit:
+                card.set_trump()
 
-			if trump_suit == 'H':
-				left_bower = ['D','J']
-			elif trump_suit == 'D':
-				left_bower = ['H','J']
-			elif trump_suit == 'C':
-				left_bower = ['S','J']
-			elif trump_suit == 'S':
-				left_bower = ['C','J']
-			
-			if card.get_desc() == left_bower:
-				card.set_left()
-
-
-		
+            if trump_suit == 'H':
+                left_bower = ['D','J']
+            elif trump_suit == 'D':
+                left_bower = ['H','J']
+            elif trump_suit == 'C':
+                left_bower = ['S','J']
+            elif trump_suit == 'S':
+                left_bower = ['C','J']
+            
+            if card.get_desc() == left_bower:
+                card.set_left(trump_suit)


### PR DESCRIPTION
Hi Patrick,

I stumbled across this repo and it really helped me get started with a personal project.  I noticed the following gameplay issues related to the UI that I was able to fix with this commit:

1. Set left-bower suit to be trump
2. Rotate dealer clockwise after each round (was random before)
3. Update `rect` locations for each card after playing a card and moving cards over to the left
4. Remove loop over events within while loop in `play_game` so that game doesn't go on infinitely

There are still a few things I wanted to work on, but haven't had the time.  I may submit a later pull request adding these.

- [ ] Option for the user/partner to choose to go alone in the UI
- [ ] Move suit marker next to the player who called Trump
- [ ] Count the number of tricks per player throughout the round
- [ ] Gray out user's cards that are not valid moves, and sort the hand by value.
- [ ] Rotate cards to be in line with the player who played it (to tell who played which card)
